### PR TITLE
Mudança do cursor nos botões de Próxima e Anterior

### DIFF
--- a/src/Components/Deputados/deputados.css
+++ b/src/Components/Deputados/deputados.css
@@ -59,4 +59,5 @@
     justify-content: center;
     align-items: center;
     transition: all 0.2s;
+    cursor: pointer;
 }


### PR DESCRIPTION
#10 

**Descrição do bug/feature:**
Mudança no cursor do mouse nos botões de `Próxima` e `Anterior` na tela de deputados.

**Solução**
Adicionar a propriedade `cursor` com o valor `pointer` no css