### PR TITLE
[BUGFIX] Width bug in a search card

### DIFF
--- a/src/Components/Partidos/partidos.js
+++ b/src/Components/Partidos/partidos.js
@@ -66,7 +66,7 @@ const Partidos = () => {
             </nav>
 
             <div className="partidos-lista columns-fix">
-                <div className="columns is-multiline is-centered">
+                <div className={`columns is-multiline ${partidos.length > 2 ? 'is-centered' : ''} `}>
                     {partidos.map(partido => (
                         <div className="column is-4">
                             <article key={partido.id} className="card">

--- a/src/Components/Partidos/partidos.scss
+++ b/src/Components/Partidos/partidos.scss
@@ -2,6 +2,7 @@
 
 .partidos-lista {
     font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
+    width: 100%;
 }
 
 article {


### PR DESCRIPTION
#38 

**Descrição do bug/feature:**
PR que resolve o bug na largura do card quando faz uma busca na tela de partido.

**Solução**
Foi colocado uma propriedade de largura 100% no container das colunas e uma condicional na classe do container para quando o resultado retornar menos que dois objetos, não colocar a classe `is-centered` para o layout ficar mais harmônico.

